### PR TITLE
計測用のdocker-composeの追加/nginx用にalpを追加

### DIFF
--- a/isucon7-qualifier/docker-compose.bench.yml
+++ b/isucon7-qualifier/docker-compose.bench.yml
@@ -13,8 +13,8 @@ services:
     build:
       context: ./isucon7-qualify
       dockerfile: ../docker/web/Dockerfile
-      target: runner
-    image: isucon7-qualifier-web:nginx
+      target: bench
+    image: isucon7-qualifier-web-bench:nginx
     networks:
       - frontend
       - backend
@@ -26,7 +26,7 @@ services:
     build:
       context: ./isucon7-qualify
       dockerfile: ../docker/app/nodejs/Dockerfile
-    image: isucon7-qualifier-app:nodejs
+    image: isucon7-qualifier-app-bench:nodejs
     networks:
       - backend
     depends_on:
@@ -41,7 +41,7 @@ services:
     build:
       context: ./isucon7-qualify
       dockerfile: ../docker/db/Dockerfile
-    image: isucon7-qualifier-db
+    image: isucon7-qualifier-db-bench
     ports:
       - "3306"
     networks:

--- a/isucon7-qualifier/docker/web/Dockerfile
+++ b/isucon7-qualifier/docker/web/Dockerfile
@@ -1,9 +1,14 @@
-FROM alpine AS build-dev
+FROM nginx:1.10 AS runner
 
-COPY . /isubata
+COPY . /home/isucon/isubata
+COPY ./web/isucon.conf /etc/nginx/conf.d/isucon.conf
 
-FROM nginx:1.10
+FROM nginx:1.25.2 AS bench
 
-COPY --from=build-dev /isubata /home/isucon/isubata
-#COPY --from=build-dev /isubata/files/app/nginx.conf /etc/nginx/conf.d/isucon.conf
-COPY --from=build-dev /isubata/web/isucon.conf /etc/nginx/conf.d/isucon.conf
+RUN apt update && apt upgrade && apt install -y wget
+
+RUN wget https://github.com/tkuchiki/alp/releases/download/v1.0.20/alp_linux_amd64.tar.gz \
+    && tar -xvzf ./alp_linux_amd64.tar.gz
+COPY --from=runner /home/isucon/isubata /home/isucon/isubata
+COPY --from=runner /etc/nginx/conf.d/isucon.conf /etc/nginx/conf.d/isucon.conf
+COPY ./web/bench/log.conf /etc/nginx/conf.d/log.conf

--- a/isucon7-qualifier/isucon7-qualify/bench/.gitignore
+++ b/isucon7-qualifier/isucon7-qualify/bench/.gitignore
@@ -1,3 +1,2 @@
 bin
 pkg
-vendor

--- a/isucon7-qualifier/isucon7-qualify/bench/vendor/manifest
+++ b/isucon7-qualifier/isucon7-qualify/bench/vendor/manifest
@@ -1,0 +1,30 @@
+{
+	"version": 0,
+	"dependencies": [
+		{
+			"importpath": "github.com/PuerkitoBio/goquery",
+			"repository": "https://github.com/PuerkitoBio/goquery",
+			"revision": "ce645ea5e67a713599b7415f21f0786451fa9554",
+			"branch": "master"
+		},
+		{
+			"importpath": "github.com/andybalholm/cascadia",
+			"repository": "https://github.com/andybalholm/cascadia",
+			"revision": "349dd0209470eabd9514242c688c403c0926d266",
+			"branch": "master"
+		},
+		{
+			"importpath": "github.com/marcw/cachecontrol",
+			"repository": "https://github.com/marcw/cachecontrol",
+			"revision": "30341fe9a7d531c7bc6414af55ceb59b9e61499a",
+			"branch": "master"
+		},
+		{
+			"importpath": "golang.org/x/net/html",
+			"repository": "https://go.googlesource.com/net",
+			"revision": "1c05540f6879653db88113bc4a2b70aec4bd491f",
+			"branch": "master",
+			"path": "/html"
+		}
+	]
+}

--- a/isucon7-qualifier/isucon7-qualify/web/bench/log.conf
+++ b/isucon7-qualifier/isucon7-qualify/web/bench/log.conf
@@ -1,0 +1,17 @@
+log_format ltsv "time:$time_local"
+  "\thost:$remote_addr"
+  "\tforwardedfor:$http_x_forwarded_for"
+  "\treq:$request"
+  "\tmethod:$request_method"
+  "\turi:$request_uri"
+  "\tstatus:$status"
+  "\tsize:$body_bytes_sent"
+  "\treferer:$http_referer"
+  "\tua:$http_user_agent"
+  "\treqtime:$request_time"
+  "\truntime:$upstream_http_x_runtime"
+  "\tapptime:$upstream_response_time"
+  "\tcache:$upstream_http_x_cache"
+  "\tvhost:$host";
+
+access_log /var/log/nginx/access_1.log ltsv;

--- a/isucon7-qualifier/my-bench/alp.sh
+++ b/isucon7-qualifier/my-bench/alp.sh
@@ -1,1 +1,1 @@
-docker compose exec web ./alp ltsv --file /var/log/nginx/access_1.log
+docker compose exec web ./alp ltsv --file /var/log/nginx/access_1.log -m '/icons/.*,/fonts/.*,/channel/[0-9]+,/profile/.*,/history/[0-9]+' --sort avg -r

--- a/isucon7-qualifier/my-bench/alp.sh
+++ b/isucon7-qualifier/my-bench/alp.sh
@@ -1,0 +1,1 @@
+docker compose exec web ./alp ltsv --file /var/log/nginx/access_1.log


### PR DESCRIPTION
パフォーマンス改善は行っていないため、ベンチの証跡は残さない